### PR TITLE
Update R version and fix install.packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -109,7 +109,7 @@ EXPOSE 3838
 COPY app/*.R /srv/shiny-server/
 COPY app/data /srv/shiny-server/data
 COPY app/www /srv/shiny-server/www
-RUN R -e "install.packages( ${RLIBS} )"
+RUN R -e "install.packages(c( ${RLIBS} ))"
 
 # -----------------------------------------
 #

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ ENV LANG en_US.UTF-8
 RUN echo "deb http://http.debian.net/debian sid main" > /etc/apt/sources.list.d/debian-unstable.list \
     && echo 'APT::Default-Release "testing";' > /etc/apt/apt.conf.d/default
 
-ENV R_BASE_VERSION 3.3.1
+ENV R_BASE_VERSION 3.3.2
 
 ## Now install R and littler, and create a link for littler in /usr/local/bin
 ## Also set a default CRAN repo, and make sure littler knows about it too

--- a/Dockerfile
+++ b/Dockerfile
@@ -95,6 +95,17 @@ ADD tools/shiny-server.conf /etc/shiny-server/
 
 # --------------------------------------------------------
 #
+# Make and set permissions for log & bookmarks directories
+#
+# --------------------------------------------------------
+
+RUN sudo mkdir -p /var/shinylogs/shiny-server && \
+    mkdir -p /var/lib/shiny-server && \
+    chown shiny:shiny /var/shinylogs/shiny-server/ && \
+    chown shiny:shiny /var/lib/shiny-server/
+
+# --------------------------------------------------------
+#
 # expose the 3838 port
 #
 # --------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ The packages.txt file should look something like this:
 ```
 with all packages on the same line.
 
+Do not include 'shiny' or 'rmarkdown' in packages.txt as they are installed automatically.
+
 ### 5. Run / Develop
 
 With all your packages listed in the packages.txt file, and your code in the app directory you should be able to run ./dev.sh at the command line in the root of your project

--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ will appear in the root of your project under the '_mount' directory:
 - **_mount/output**    : In your program, if you write to '/srv/shiny-server-output' it will show up here
 - **_mount/tmp**       : The /tmp directory if you need to debug the temporary files created by shiny
 
+Note: If you are on Windows and using Docker with VirtualBox, use the `dev-win.sh` instead of `dev.sh` - It unfortunately won't be able to mount the logs and bookmarks folders locally, but it will build and lanch the app.
+
 The first time you run dev.sh you will see a lot of output where docker is building the container image for the first time and installing all the dependancies.
 On each successive run as you modify your code and run dev.sh, you will see that only your new code gets placed into the image and run.  If you add new packages
 *do not forget to update the packages.txt file* or you will see the missing packages errors in your R program logs.

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # Shiny Server Development Template
 
-## Intoduction
+## Introduction
 
-This repo is intended to be forked and used as a development repo for R applicaitons that use shiny as a visualization server.  The code is designed
+This repo is intended to be forked and used as a development repo for R applications that use [Shiny](http://shiny.rstudio.com/) as a visualization server.  The code is designed
 to run locally in development using Docker, and can be productionized using your github repo through OpenShift.
 
 ### Where do I put my code?
 
 All of your code goes into the app directory. Data goes into the app/data directory and web resources such as css and images go into app/www directory.
-If you have a README for your project, please also put it here.  Your shiny code can go into one file as per the example, or you can split it into
+If you have a README for your project, please also put it here.  Your Shiny code can go into one file as per the example, or you can split it into
 seperate ui and server files as you wish.
 
 ## Getting Started
@@ -32,7 +32,7 @@ found [here](https://git-scm.com/book/en/v2/Git-Basics-Getting-a-Git-Repository 
 
 ### 4. Edit the packages.txt file
 
-The packages.txt file contains an array of strings that indicate the packages you will will be using in your R program.  This list is used when building your local Dockerfile so that the
+The packages.txt file contains an array of strings that indicate the packages you will be using in your R program.  This list is used when building your local Dockerfile so that the
 build process runs as fast as possible.  If you are familiar with Docker you know that you can also set environment variables that import this information, however this prevents the build process
 from using the cached layer for this step.  Therefore the packages.txt file is used to build an explicit local Dockerfile that ensures fast repeated builds.
 
@@ -46,8 +46,7 @@ Do not include 'shiny' or 'rmarkdown' in packages.txt as they are installed auto
 
 ### 5. Run / Develop
 
-With all your packages listed in the packages.txt file, and your code in the app directory you should be able to run ./dev.sh at the command line in the root of your project
-to initiate Docker.
+With all your packages listed in the packages.txt file, and your code in the app directory you should be able to run `./dev.sh` at the command line in the root of your project to initiate Docker.
 ```
 $ ./dev.sh
 ```
@@ -59,7 +58,7 @@ will appear in the root of your project under the '_mount' directory:
 - **_mount/output**    : In your program, if you write to '/srv/shiny-server-output' it will show up here
 - **_mount/tmp**       : The /tmp directory if you need to debug the temporary files created by shiny
 
-Note: If you are on Windows and using Docker with VirtualBox, use the `dev-win.sh` instead of `dev.sh` - It unfortunately won't be able to mount the logs and bookmarks folders locally, but it will build and lanch the app.
+Note: If you are on Windows and using Docker with VirtualBox, use the `dev-win.sh` file instead of `dev.sh` - It unfortunately won't be able to mount the logs and bookmarks folders locally, but it will build and lanch the app.
 
 The first time you run dev.sh you will see a lot of output where docker is building the container image for the first time and installing all the dependancies.
 On each successive run as you modify your code and run dev.sh, you will see that only your new code gets placed into the image and run.  If you add new packages

--- a/dev-win.sh
+++ b/dev-win.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+# --------------------------------------------------------
+#
+# This script both builds and runs the local R-Shiny app
+# using the docker file supplied.
+#
+# --------------------------------------------------------
+
+# --------------------------------------------------------
+#
+# create the local dockerfile
+#
+# --------------------------------------------------------
+if [[ $(diff packages.txt .packages.txt) ]] || [[ ! -f Dockerfile.local ]]
+then
+	sed -e "s/\${RLIBS}/$(head -n 1 packages.txt)/"  Dockerfile > Dockerfile.local
+fi
+cp packages.txt .packages.txt
+
+# --------------------------------------------------------
+#
+# Build
+#
+# --------------------------------------------------------
+docker build -t myshiny -f Dockerfile.local .
+
+# --------------------------------------------------------
+#
+# Run the image - unfortunately won't mount the logs and
+# bookmarks locally
+#
+# --------------------------------------------------------
+docker run -i -t --rm --name shiny -p 3838:3838 myshiny


### PR DESCRIPTION
This updates the base R version (now at 3.3.2), and adds the `c()` function around the RLIBS variable in `install.packages()` to accommodate a list of one or more packages.